### PR TITLE
Fix close method that could close the wrong notification

### DIFF
--- a/fake-browser.html
+++ b/fake-browser.html
@@ -1,33 +1,43 @@
 <!doctype html>
 <html>
-
-<head>
+  <head>
     <meta charset="utf-8">
     <title></title>
-</head>
+  </head>
 
-<body>
-
+  <body>
     <script type="text/javascript">
-        const {
-            ipcRenderer,
-        } = require('electron');
+      const {
+        ipcRenderer,
+      } = require('electron');
 
-        let notification;
+      let activeNotifications = [];
 
-        ipcRenderer.on('display-notification', (event, arg) => {
-            notification = new Notification(arg.title, arg.opts);
-            notification.onclick = () => ipcRenderer.send('display-notification-onclick', arg.uuid);
-            notification.onshow = () => ipcRenderer.send('display-notification-onshow', arg.uuid);
-            notification.onclose = () => ipcRenderer.send('display-notification-onclose', arg.uuid);
-            notification.onerror = (err) => ipcRenderer.send('display-notification-onerror', arg.uuid, err);
+      ipcRenderer.on('display-notification', (event, params) => {
+        let notification = new Notification(params.title, params.opts);
+
+        notification.onclick = () => ipcRenderer.send('display-notification-onclick', params.uuid);
+        notification.onshow = () => ipcRenderer.send('display-notification-onshow', params.uuid);
+        notification.onerror = (err) => ipcRenderer.send('display-notification-onerror', params.uuid, err);
+
+        notification.onclose = () => {
+          activeNotifications = activeNotifications.filter((item) => item.uuid !== params.uuid);
+          ipcRenderer.send('display-notification-onclose', params.uuid);
+        };
+
+        activeNotifications.push({
+          uuid: params.uuid,
+          notification,
         });
+      });
 
-        ipcRenderer.on('close-notification', (event, arg) => {
-            if (notification)
-                notification.close();
-        });
+      ipcRenderer.on('close-notification', (event, { uuid }) => {
+        for (const item of activeNotifications) {
+          if (item.uuid === uuid) {
+            item.notification.close();
+          }
+        }
+      });
     </script>
-</body>
-
+  </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class Notification extends EventEmitter {
     this._dir = opts.dir;
     this._icon = opts.icon;
     this._timestamp = opts.timestamp;
+    this._uuid = uuid;
 
     this._onclick = null;
     this._onerror = null;
@@ -82,7 +83,7 @@ class Notification extends EventEmitter {
   }
 
   close() {
-    window.webContents.send('close-notification');
+    window.webContents.send('close-notification', { uuid: this._uuid });
   }
 
   set onclick(callback) {


### PR DESCRIPTION
I noticed that there was a bug with closing notifications when multiple notifications are opened.

As the BrowserWindow script only kept tracks of the active notification and not an array of active notifications, when the close command was received from the main process it would close the active notification but not always the one matching the uuid.

Fixed by keeping track of notifications in an array instead of just a single variable.

Let me know if you have any question 🚀